### PR TITLE
For jumping to 5% when increasing from 15 to 25% issue (AI)

### DIFF
--- a/brightness-control
+++ b/brightness-control
@@ -41,7 +41,8 @@ for p in "${targets_pct[@]}"; do
   # Clamp and ensure strictly increasing sequence (dedup if rounding collides)
   (( raw < 0 )) && raw=0
   (( raw > max )) && raw="$max"
-  if ((${#raw_targets[@]}==0)) || (( raw > raw_targets[-1] )); then
+  # Always include 5% and 100% to maintain array alignment between targets_pct and raw_targets
+  if ((${#raw_targets[@]}==0)) || (( raw > raw_targets[-1] )) || (( p == 5 )) || (( p == 100 )); then
     raw_targets+=("$raw")
   fi
 done
@@ -72,35 +73,19 @@ fi
 brightnessctl set "$next" >/dev/null
 
 # OSD (show percent of the *new* raw)
-# Map ALL brightness values to their intended display percentages
-case "$next" in
-  0)   new_percent=0 ;;
-  1)   new_percent=1 ;;
-  2)   new_percent=2 ;;
-  4)   new_percent=3 ;;
-  9)   new_percent=4 ;;
-  20)  new_percent=5 ;;
-  40)  new_percent=10 ;;
-  60)  new_percent=15 ;;
-  80)  new_percent=20 ;;
-  100) new_percent=25 ;;
-  120) new_percent=30 ;;
-  140) new_percent=35 ;;
-  160) new_percent=40 ;;
-  180) new_percent=45 ;;
-  200) new_percent=50 ;;
-  220) new_percent=55 ;;
-  240) new_percent=60 ;;
-  260) new_percent=65 ;;
-  280) new_percent=70 ;;
-  300) new_percent=75 ;;
-  320) new_percent=80 ;;
-  340) new_percent=85 ;;
-  360) new_percent=90 ;;
-  380) new_percent=95 ;;
-  400) new_percent=100 ;;
-  *)   new_percent=$(( next * 100 / max )) ;;  # fallback for any other values
-esac
+# Map raw values to their intended display percentages using the same arrays
+new_percent=""
+for i in "${!raw_targets[@]}"; do
+  if (( raw_targets[i] == next )); then
+    new_percent="${targets_pct[i]}"
+    break
+  fi
+done
+
+# Fallback if not found (shouldn't happen)
+if [[ -z "$new_percent" ]]; then
+  new_percent=$(( next * 100 / max ))
+fi
 
 # Use custom progress to show bar without swayosd overriding our brightness
 # CRITICAL: swayosd-client --brightness X actively sets brightness to X% of max,


### PR DESCRIPTION
First of all thank you!
Thank you for the time you've put to set up the repo, write the readme, tell the internet about it!

I had an issue on my old macbook pro 2015 increasing brightness from 15% would show 5% while the real brightness was about the same.
I've used a vibecoding tool to vibecode the fix, so I don't really know what is going on here, but it works.

I could make an issue instead of PR